### PR TITLE
Move error strings to constants for easier error overview/maintenance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A command bus to demand all the things.
 4. [The Bus](#The-Bus)  
    1. [Tweaking Performance](#Tweaking-Performance)  
    2. [Shutting Down](#Shutting-Down)  
+   3. [Available Errors](#Available-Errors)
 5. [Benchmarks](#Benchmarks)
 6. [Examples](#Examples)
 
@@ -81,6 +82,13 @@ bus.Shutdown()
 ```  
 **This function will block until the bus is fully stopped.**
 
+#### Available Errors
+Below is a list of errors that can occur when calling ```bus.HandleAsync or bus.Handle```.  
+```
+command.ErrorInvalidCommand
+command.ErrorCommandBusNotInitialized
+command.ErrorCommandBusIsShuttingDown
+```
 ## Benchmarks
 All the benchmarks are performed against batches of 1 million commands.  
 All the benchmarks contain some overhead due to the usage of _sync.WaitGroup_.  

--- a/README.md
+++ b/README.md
@@ -84,10 +84,24 @@ bus.Shutdown()
 
 #### Available Errors
 Below is a list of errors that can occur when calling ```bus.HandleAsync or bus.Handle```.  
-```
-command.ErrorInvalidCommand
-command.ErrorCommandBusNotInitialized
-command.ErrorCommandBusIsShuttingDown
+```go
+// command.ErrorInvalidCommand
+// command.ErrorCommandBusNotInitialized
+// command.ErrorCommandBusIsShuttingDown
+
+if err := bus.handle(&Command{}); err != nil {
+    switch(err.(type)) {
+        case command.ErrorInvalidCommand:
+            // do something
+        case command.CommandBusNotInitializedError:
+            // do something
+        case command.CommandBusIsShuttingDownError:
+            // do something
+        default:
+            // do something
+    }
+}
+
 ```
 ## Benchmarks
 All the benchmarks are performed against batches of 1 million commands.  

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Below is a list of errors that can occur when calling ```bus.HandleAsync or bus.
 // command.ErrorCommandBusNotInitialized
 // command.ErrorCommandBusIsShuttingDown
 
-if err := bus.handle(&Command{}); err != nil {
+if err := bus.Handle(&Command{}); err != nil {
     switch(err.(type)) {
         case command.ErrorInvalidCommand:
             // do something

--- a/bus.go
+++ b/bus.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"errors"
 	"runtime"
 	"sync/atomic"
 )
@@ -19,12 +18,6 @@ type Bus struct {
 	asyncCommandsQueue chan Command
 	closed             chan bool
 }
-
-const (
-	ErrorInvalidCommand           = "invalid command"
-	ErrorCommandBusNotInitialized = "the command bus is not initialized"
-	ErrorCommandBusIsShuttingDown = "the command bus is shutting down"
-)
 
 // NewBus instantiates the Bus struct.
 // The Initialization of the Bus is performed separately (Initialize function) for dependency injection purposes.
@@ -159,17 +152,17 @@ func (bus *Bus) shutdown() {
 func (bus *Bus) isValid(cmd Command) error {
 	var err error
 	if cmd == nil {
-		err = errors.New(ErrorInvalidCommand)
+		err = ErrorInvalidCommand(InvalidCommandError)
 		bus.error(cmd, err)
 		return err
 	}
 	if !bus.isInitialized() {
-		err = errors.New(ErrorCommandBusNotInitialized)
+		err = ErrorCommandBusNotInitialized(CommandBusNotInitializedError)
 		bus.error(cmd, err)
 		return err
 	}
 	if bus.isShuttingDown() {
-		err = errors.New(ErrorCommandBusIsShuttingDown)
+		err = ErrorCommandBusIsShuttingDown(CommandBusIsShuttingDownError)
 		bus.error(cmd, err)
 		return err
 	}

--- a/bus.go
+++ b/bus.go
@@ -20,6 +20,12 @@ type Bus struct {
 	closed             chan bool
 }
 
+const (
+	ErrorInvalidCommand           = "invalid command"
+	ErrorCommandBusNotInitialized = "the command bus is not initialized"
+	ErrorCommandBusIsShuttingDown = "the command bus is shutting down"
+)
+
 // NewBus instantiates the Bus struct.
 // The Initialization of the Bus is performed separately (Initialize function) for dependency injection purposes.
 func NewBus() *Bus {
@@ -153,17 +159,17 @@ func (bus *Bus) shutdown() {
 func (bus *Bus) isValid(cmd Command) error {
 	var err error
 	if cmd == nil {
-		err = errors.New("invalid command")
+		err = errors.New(ErrorInvalidCommand)
 		bus.error(cmd, err)
 		return err
 	}
 	if !bus.isInitialized() {
-		err = errors.New("the command bus is not initialized")
+		err = errors.New(ErrorCommandBusNotInitialized)
 		bus.error(cmd, err)
 		return err
 	}
 	if bus.isShuttingDown() {
-		err = errors.New("the command bus is shutting down")
+		err = errors.New(ErrorCommandBusIsShuttingDown)
 		bus.error(cmd, err)
 		return err
 	}

--- a/bus.go
+++ b/bus.go
@@ -152,17 +152,17 @@ func (bus *Bus) shutdown() {
 func (bus *Bus) isValid(cmd Command) error {
 	var err error
 	if cmd == nil {
-		err = ErrorInvalidCommand(InvalidCommandError)
+		err = InvalidCommandError
 		bus.error(cmd, err)
 		return err
 	}
 	if !bus.isInitialized() {
-		err = ErrorCommandBusNotInitialized(CommandBusNotInitializedError)
+		err = CommandBusNotInitializedError
 		bus.error(cmd, err)
 		return err
 	}
 	if bus.isShuttingDown() {
-		err = ErrorCommandBusIsShuttingDown(CommandBusIsShuttingDownError)
+		err = CommandBusIsShuttingDownError
 		bus.error(cmd, err)
 		return err
 	}

--- a/errors.go
+++ b/errors.go
@@ -1,11 +1,5 @@
 package command
 
-const (
-	InvalidCommandError           = "command: invalid command"
-	CommandBusNotInitializedError = "command: the command bus is not initialized"
-	CommandBusIsShuttingDownError = "command: the command bus is shutting down"
-)
-
 type ErrorInvalidCommand string
 
 func (e ErrorInvalidCommand) Error() string {
@@ -23,3 +17,9 @@ type ErrorCommandBusIsShuttingDown string
 func (e ErrorCommandBusIsShuttingDown) Error() string {
 	return string(e)
 }
+
+const (
+	InvalidCommandError           = ErrorInvalidCommand("command: invalid command")
+	CommandBusNotInitializedError = ErrorCommandBusNotInitialized("command: the command bus is not initialized")
+	CommandBusIsShuttingDownError = ErrorCommandBusIsShuttingDown("command: the command bus is shutting down")
+)

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,25 @@
+package command
+
+const (
+	InvalidCommandError           = "command: invalid command"
+	CommandBusNotInitializedError = "command: the command bus is not initialized"
+	CommandBusIsShuttingDownError = "command: the command bus is shutting down"
+)
+
+type ErrorInvalidCommand string
+
+func (e ErrorInvalidCommand) Error() string {
+	return string(e)
+}
+
+type ErrorCommandBusNotInitialized string
+
+func (e ErrorCommandBusNotInitialized) Error() string {
+	return string(e)
+}
+
+type ErrorCommandBusIsShuttingDown string
+
+func (e ErrorCommandBusIsShuttingDown) Error() string {
+	return string(e)
+}


### PR DESCRIPTION
This would allow handling of specific errors without "magic" strings.

```go
bus := command.NewBus()
err := bus.HandleAsync(&command.Command{})

if err := bus.Handle(&Command{}); err != nil {
    switch(err.(type)) {
        case command.ErrorInvalidCommand:
            // do something
        case command.CommandBusNotInitializedError:
            // do something
        case command.CommandBusIsShuttingDownError:
            // do something
        default:
            // do something
    }
}
```